### PR TITLE
JSON stringify support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,10 @@ abstract class DataStr {
     return this.val
   }
 
+  toJSON () {
+    return this.toString()
+  }
+
   eq (n: DataStr): boolean {
     return this.toBN().eq(n.toBN())
   }


### PR DESCRIPTION
Adds a `toJSON` method to automatically stringify as described [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#description).